### PR TITLE
忽略没有后缀的文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Linux Executables
+*
+!*.*
+!*/
+
 # Prerequisites
 *.d
 


### PR DESCRIPTION
linux下的可执行文件是没有后缀的。如果你哪天在linux上手抖把二进制文件给commit了，这个repo就永远带着那个大型文件了。

1. ignore所有文件
2. 再把带后缀名的文件取消ignore。
3. 然而这么操作完后在文件夹中的新增文件是不会被track到的，所以必须加上`!*/`把所有的文件夹也取消ignore。（这一步坑了我小半年）

我并没有google到其他的方法。